### PR TITLE
Update config file

### DIFF
--- a/src/combined.yml
+++ b/src/combined.yml
@@ -184,14 +184,59 @@ core:
       events: {}
       msg_def_overrides:
         - parent: CFE_ES_AppInfo_t
+          member: Type
+          type: enumeration
+          enumerations:
+            CFE_ES_APP_TYPE_CORE: 1
+            CFE_ES_APP_TYPE_EXTERNAL: 2
+        - parent: CFE_ES_AppInfo_t
           member: Name
           type: string
+        - parent: CFE_ES_AppInfo_t
+          member: EntryPoint
+          type: string
+        - parent: CFE_ES_AppInfo_t
+          member: FileName
+          type: string
+        - parent: CFE_ES_AppInfo_t
+          member: MainTaskName
+          type: string
+        - parent: CFE_ES_OverWriteSysLogCmd_Payload_t
+          member: Mode
+          type: enumeration
+          enumerations:
+            CFE_ES_LOG_OVERWRITE: 0
+            CFE_ES_LOG_DISCARD: 1
         - parent: CFE_ES_HkPacket_Payload_t
           member: SysLogMode
           type: enumeration
           enumerations:
             OVERWRITE: 0
             DROP: 1
+        - parent: CFE_ES_StartAppCmd_Payload_t
+          member: Application
+          type: string
+        - parent: CFE_ES_StartAppCmd_Payload_t
+          member: AppEntryPoint
+          type: string
+        - parent: CFE_ES_StartAppCmd_Payload_t
+          member: AppFileName
+          type: string
+        - parent: CFE_ES_StartAppCmd_Payload_t
+          member: ExceptionAction
+          type: enumeration
+          enumerations:
+            CFE_ES_APP_EXCEPTION_RESTART_APP: 0
+            CFE_ES_APP_EXCEPTION_PROC_RESTART: 1
+        - parent: CFE_ES_AppNameCmd_Payload_t
+          member: Application
+          type: string
+        - parent: CFE_EVS_Packet_Payload_t
+          member: Message
+          type: string
+        - parent: CFE_EVS_PacketID_t
+          member: AppName
+          type: string
       telemetry:
         CFE_ES_HK_TLM_MID:
           msgID: 0x0800

--- a/src/combined.yml
+++ b/src/combined.yml
@@ -2,7 +2,7 @@
 config_base: ".."
 core:
   elf_files:
-    - ../airliner/build/build/tutorial/cfs/target/exe/airliner
+    - ../airliner/build/tutorial/cfs/target/exe/airliner
 
   osal:
     config:
@@ -1362,7 +1362,7 @@ core:
 modules:
   ak8963:
     elf_files:
-      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/ak8963.so
+      - ../airliner/build/tutorial/cfs/target/exe/cf/apps/ak8963.so
     short_name: ak8963
     long_name: TBD
     events:
@@ -1517,7 +1517,7 @@ modules:
     definition: "../apps/ak8963"
   icm20689:
     elf_files:
-      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/ICM20689.so
+      - ../airliner/build/tutorial/cfs/target/exe/cf/apps/ICM20689.so
     short_name: imc
     long_name: Actuator Motor Control
     events:
@@ -1688,7 +1688,7 @@ modules:
 
   amc:
     elf_files:
-      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/amc.so
+      - ../airliner/build/tutorial/cfs/target/exe/cf/apps/amc.so
     short_name: amc
     long_name: Actuator Motor Control
     events:
@@ -1858,7 +1858,7 @@ modules:
     definition: "../apps/amc"
   bat:
     elf_files:
-      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/bat.so
+      - ../airliner/build/tutorial/cfs/target/exe/cf/apps/bat.so
     short_name: bat
     long_name: Battery Manager
     events:
@@ -1982,7 +1982,7 @@ modules:
     definition: "../apps/bat"
   cf:
     elf_files:
-      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/CF.so
+      - ../airliner/build/tutorial/cfs/target/exe/cf/apps/CF.so
     short_name: cf
     long_name: CFDP File Delivery
     events:
@@ -2654,7 +2654,7 @@ modules:
     definition: "../apps/cf"
   ci:
     elf_files:
-      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/CI.so
+      - ../airliner/build/tutorial/cfs/target/exe/cf/apps/CI.so
     short_name: ci
     long_name: Command Ingest
     events:
@@ -2887,7 +2887,7 @@ modules:
     definition: "../apps/ci"
   cs:
     elf_files:
-      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/CS.so
+      - ../airliner/build/tutorial/cfs/target/exe/cf/apps/CS.so
     short_name: cs
     long_name: Checksum Services
     events:
@@ -3545,7 +3545,7 @@ modules:
     definition: "../apps/cs"
   ds:
     elf_files:
-      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/DS.so
+      - ../airliner/build/tutorial/cfs/target/exe/cf/apps/DS.so
     short_name: ds
     long_name: Data Storage
     events:
@@ -3867,7 +3867,7 @@ modules:
     definition: "../apps/ds"
   ea:
     elf_files:
-      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/EA.so
+      - ../airliner/build/tutorial/cfs/target/exe/cf/apps/EA.so
     short_name: ea
     long_name: External Application
     events:
@@ -4013,7 +4013,7 @@ modules:
 
   flow:
     elf_files:
-      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/FLOW.so
+      - ../airliner/build/tutorial/cfs/target/exe/cf/apps/FLOW.so
     short_name: flow
     long_name: Optical Flow
     events:
@@ -4151,7 +4151,7 @@ modules:
     definition: "../apps/flow"
   fm:
     elf_files:
-      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/FM.so
+      - ../airliner/build/tutorial/cfs/target/exe/cf/apps/FM.so
     short_name: fm
     long_name: File Management
     events:
@@ -4641,7 +4641,7 @@ modules:
 
   gps:
     elf_files:
-      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/GPS.so
+      - ../airliner/build/tutorial/cfs/target/exe/cf/apps/GPS.so
     short_name: gps
     long_name: GPS Driver
     events:
@@ -4767,7 +4767,7 @@ modules:
 
   hk:
     elf_files:
-      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/HK.so
+      - ../airliner/build/tutorial/cfs/target/exe/cf/apps/HK.so
     short_name: hk
     long_name: Housekeeping
     events:
@@ -4940,7 +4940,7 @@ modules:
 
   hmc5883:
     elf_files:
-      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/HMC5883.so
+      - ../airliner/build/tutorial/cfs/target/exe/cf/apps/HMC5883.so
     short_name: hmc5883
     long_name:
     events:
@@ -5098,7 +5098,7 @@ modules:
     definition: "../apps/hmc5883"
   hs:
     elf_files:
-      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/HS.so
+      - ../airliner/build/tutorial/cfs/target/exe/cf/apps/HS.so
     short_name: hs
     long_name: Heath Services
     events:
@@ -5513,7 +5513,7 @@ modules:
 
   lc:
     elf_files:
-      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/LC.so
+      - ../airliner/build/tutorial/cfs/target/exe/cf/apps/LC.so
     short_name: lc
     long_name: Limits Checker
     events:
@@ -5811,7 +5811,7 @@ modules:
 
   ld:
     elf_files:
-      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/LD.so
+      - ../airliner/build/tutorial/cfs/target/exe/cf/apps/LD.so
     short_name: ld
     long_name: Landing Determination
     events:
@@ -5939,7 +5939,7 @@ modules:
 
   lgc:
     elf_files:
-      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/LGC.so
+      - ../airliner/build/tutorial/cfs/target/exe/cf/apps/LGC.so
     short_name: lgc
     long_name: Landing Gear Control
     events:
@@ -6067,7 +6067,7 @@ modules:
 
   mac:
     elf_files:
-      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/MAC.so
+      - ../airliner/build/tutorial/cfs/target/exe/cf/apps/MAC.so
     short_name: mac
     long_name: Multicopter Attitude Controller
     events:
@@ -6171,7 +6171,7 @@ modules:
 
   mavlink:
     elf_files:
-      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/MAVLINK.so
+      - ../airliner/build/tutorial/cfs/target/exe/cf/apps/MAVLINK.so
     short_name: mavlink
     long_name: Mavlink Interface
     events:
@@ -6317,7 +6317,7 @@ modules:
 
   md:
     elf_files:
-      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/MD.so
+      - ../airliner/build/tutorial/cfs/target/exe/cf/apps/MD.so
     short_name: md
     long_name: Memory Dwell
     events:
@@ -6517,7 +6517,7 @@ modules:
 
   mm:
     elf_files:
-      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/MM.so
+      - ../airliner/build/tutorial/cfs/target/exe/cf/apps/MM.so
     short_name: mm
     long_name: Memory Manager
     events:
@@ -6857,7 +6857,7 @@ modules:
 
   mpc:
     elf_files:
-      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/MPC.so
+      - ../airliner/build/tutorial/cfs/target/exe/cf/apps/MPC.so
     short_name: mpc
     long_name: Multicopter Position Controller
     events:
@@ -7015,7 +7015,7 @@ modules:
 
   mpu6050:
     elf_files:
-      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/MPU6050.so
+      - ../airliner/build/tutorial/cfs/target/exe/cf/apps/MPU6050.so
     short_name: mpu6050
     long_name:
     events:
@@ -7210,7 +7210,7 @@ modules:
 
   mpu9250:
     elf_files:
-      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/MPU9250.so
+      - ../airliner/build/tutorial/cfs/target/exe/cf/apps/MPU9250.so
     short_name: mpu9250
     long_name:
     events:
@@ -7407,7 +7407,7 @@ modules:
 
   ms5607:
     elf_files:
-      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/MS5607.so
+      - ../airliner/build/tutorial/cfs/target/exe/cf/apps/MS5607.so
     short_name: ms5607
     long_name:
     events:
@@ -7548,7 +7548,7 @@ modules:
 
   ms5611:
     elf_files:
-      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/MS5611.so
+      - ../airliner/build/tutorial/cfs/target/exe/cf/apps/MS5611.so
     short_name: ms5611
     long_name:
     events:
@@ -7679,7 +7679,7 @@ modules:
 
   nav:
     elf_files:
-      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/NAV.so
+      - ../airliner/build/tutorial/cfs/target/exe/cf/apps/NAV.so
     short_name: nav
     long_name: Navigation
     events:
@@ -7828,7 +7828,7 @@ modules:
 
   prmlib:
     elf_files:
-      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/PRMLIB.so
+      - ../airliner/build/tutorial/cfs/target/exe/cf/apps/PRMLIB.so
     short_name: prmlib
     long_name: Parameters
     events: {}
@@ -7905,7 +7905,7 @@ modules:
 
   pe:
     elf_files:
-      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/PE.so
+      - ../airliner/build/tutorial/cfs/target/exe/cf/apps/PE.so
     short_name: pe
     long_name: Position Estimator
     events:
@@ -8227,7 +8227,7 @@ modules:
 
   qae:
     elf_files:
-      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/QAE.so
+      - ../airliner/build/tutorial/cfs/target/exe/cf/apps/QAE.so
     short_name: qae
     long_name: Attitude Estimator
     events:
@@ -8360,7 +8360,7 @@ modules:
 
   rcin:
     elf_files:
-      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/RCIN.so
+      - ../airliner/build/tutorial/cfs/target/exe/cf/apps/RCIN.so
     short_name: rcin
     long_name: Radio Control Input
     events:
@@ -8484,7 +8484,7 @@ modules:
 
   rgbled:
     elf_files:
-      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/RGBLED.so
+      - ../airliner/build/tutorial/cfs/target/exe/cf/apps/RGBLED.so
     short_name: rgbled
     long_name: RGB LED Control
     events:
@@ -8598,7 +8598,7 @@ modules:
 
   sbn:
     elf_files:
-      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/SBN.so
+      - ../airliner/build/tutorial/cfs/target/exe/cf/apps/SBN.so
     short_name: sbn
     long_name: Software Bus Network
     events: {}
@@ -8616,7 +8616,7 @@ modules:
 
   sc:
     elf_files:
-      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/SC.so
+      - ../airliner/build/tutorial/cfs/target/exe/cf/apps/SC.so
     short_name: sc
     long_name: Stored Command
     events:
@@ -9089,7 +9089,7 @@ modules:
 
   sch:
     elf_files:
-      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/SCH.so
+      - ../airliner/build/tutorial/cfs/target/exe/cf/apps/SCH.so
     short_name: sch
     long_name: Scheduler
     events:
@@ -9364,7 +9364,7 @@ modules:
 
   sens:
     elf_files:
-      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/SENS.so
+      - ../airliner/build/tutorial/cfs/target/exe/cf/apps/SENS.so
     short_name: sens
     long_name: Sensor Application
     events:
@@ -9489,7 +9489,7 @@ modules:
 
   sim:
     elf_files:
-      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/SIM.so
+      - ../airliner/build/tutorial/cfs/target/exe/cf/apps/SIM.so
     short_name: sim
     long_name: Simulation Application
     events:
@@ -9626,7 +9626,7 @@ modules:
 
   sonar:
     elf_files:
-      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/SONAR.so
+      - ../airliner/build/tutorial/cfs/target/exe/cf/apps/SONAR.so
     short_name: sonar
     long_name: Sonar Driver
     events:
@@ -9763,7 +9763,7 @@ modules:
 
   to:
     elf_files:
-      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/TO.so
+      - ../airliner/build/tutorial/cfs/target/exe/cf/apps/TO.so
     short_name: to
     long_name: Telemetry Output
     events:
@@ -10013,7 +10013,7 @@ modules:
 
   ulr:
     elf_files:
-      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/ULR.so
+      - ../airliner/build/tutorial/cfs/target/exe/cf/apps/ULR.so
     short_name: ulr
     long_name: uLanding Radar Driver
     events:
@@ -10153,7 +10153,7 @@ modules:
 
   vc:
     elf_files:
-      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/VC.so
+      - ../airliner/build/tutorial/cfs/target/exe/cf/apps/VC.so
     short_name: vc
     long_name: Video Control
     events:
@@ -10360,7 +10360,7 @@ modules:
 
   vm:
     elf_files:
-      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/VM.so
+      - ../airliner/build/tutorial/cfs/target/exe/cf/apps/VM.so
     short_name: vm
     long_name: Vehicle Manager
     events:
@@ -10674,7 +10674,7 @@ modules:
 
   px4lib:
     elf_files:
-      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/PX4LIB.so
+      - ../airliner/build/tutorial/cfs/target/exe/cf/apps/PX4LIB.so
     short_name: px4lib
     long_name: PX4 Library
     events: {}

--- a/src/combined.yml
+++ b/src/combined.yml
@@ -2,7 +2,7 @@
 config_base: ".."
 core:
   elf_files:
-    - ../airliner/build/bebop2/sitl/target/exe/airliner
+    - ../airliner/build/build/tutorial/cfs/target/exe/airliner
 
   osal:
     config:
@@ -1362,7 +1362,7 @@ core:
 modules:
   ak8963:
     elf_files:
-      - ../airliner/build/bebop2/sitl/target/exe/cf/apps/ak8963.so
+      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/ak8963.so
     short_name: ak8963
     long_name: TBD
     events:
@@ -1517,7 +1517,7 @@ modules:
     definition: "../apps/ak8963"
   icm20689:
     elf_files:
-      - ../airliner/build/bebop2/sitl/target/exe/cf/apps/ICM20689.so
+      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/ICM20689.so
     short_name: imc
     long_name: Actuator Motor Control
     events:
@@ -1688,7 +1688,7 @@ modules:
 
   amc:
     elf_files:
-      - ../airliner/build/bebop2/sitl/target/exe/cf/apps/amc.so
+      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/amc.so
     short_name: amc
     long_name: Actuator Motor Control
     events:
@@ -1858,7 +1858,7 @@ modules:
     definition: "../apps/amc"
   bat:
     elf_files:
-      - ../airliner/build/bebop2/sitl/target/exe/cf/apps/bat.so
+      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/bat.so
     short_name: bat
     long_name: Battery Manager
     events:
@@ -1982,7 +1982,7 @@ modules:
     definition: "../apps/bat"
   cf:
     elf_files:
-      - ../airliner/build/bebop2/sitl/target/exe/cf/apps/CF.so
+      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/CF.so
     short_name: cf
     long_name: CFDP File Delivery
     events:
@@ -2654,7 +2654,7 @@ modules:
     definition: "../apps/cf"
   ci:
     elf_files:
-      - ../airliner/build/bebop2/sitl/target/exe/cf/apps/CI.so
+      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/CI.so
     short_name: ci
     long_name: Command Ingest
     events:
@@ -2887,7 +2887,7 @@ modules:
     definition: "../apps/ci"
   cs:
     elf_files:
-      - ../airliner/build/bebop2/sitl/target/exe/cf/apps/CS.so
+      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/CS.so
     short_name: cs
     long_name: Checksum Services
     events:
@@ -3545,7 +3545,7 @@ modules:
     definition: "../apps/cs"
   ds:
     elf_files:
-      - ../airliner/build/bebop2/sitl/target/exe/cf/apps/DS.so
+      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/DS.so
     short_name: ds
     long_name: Data Storage
     events:
@@ -3867,7 +3867,7 @@ modules:
     definition: "../apps/ds"
   ea:
     elf_files:
-      - ../airliner/build/bebop2/sitl/target/exe/cf/apps/EA.so
+      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/EA.so
     short_name: ea
     long_name: External Application
     events:
@@ -4013,7 +4013,7 @@ modules:
 
   flow:
     elf_files:
-      - ../airliner/build/bebop2/sitl/target/exe/cf/apps/FLOW.so
+      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/FLOW.so
     short_name: flow
     long_name: Optical Flow
     events:
@@ -4151,7 +4151,7 @@ modules:
     definition: "../apps/flow"
   fm:
     elf_files:
-      - ../airliner/build/bebop2/sitl/target/exe/cf/apps/FM.so
+      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/FM.so
     short_name: fm
     long_name: File Management
     events:
@@ -4641,7 +4641,7 @@ modules:
 
   gps:
     elf_files:
-      - ../airliner/build/bebop2/sitl/target/exe/cf/apps/GPS.so
+      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/GPS.so
     short_name: gps
     long_name: GPS Driver
     events:
@@ -4767,7 +4767,7 @@ modules:
 
   hk:
     elf_files:
-      - ../airliner/build/bebop2/sitl/target/exe/cf/apps/HK.so
+      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/HK.so
     short_name: hk
     long_name: Housekeeping
     events:
@@ -4940,7 +4940,7 @@ modules:
 
   hmc5883:
     elf_files:
-      - ../airliner/build/bebop2/sitl/target/exe/cf/apps/HMC5883.so
+      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/HMC5883.so
     short_name: hmc5883
     long_name:
     events:
@@ -5098,7 +5098,7 @@ modules:
     definition: "../apps/hmc5883"
   hs:
     elf_files:
-      - ../airliner/build/bebop2/sitl/target/exe/cf/apps/HS.so
+      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/HS.so
     short_name: hs
     long_name: Heath Services
     events:
@@ -5513,7 +5513,7 @@ modules:
 
   lc:
     elf_files:
-      - ../airliner/build/bebop2/sitl/target/exe/cf/apps/LC.so
+      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/LC.so
     short_name: lc
     long_name: Limits Checker
     events:
@@ -5811,7 +5811,7 @@ modules:
 
   ld:
     elf_files:
-      - ../airliner/build/bebop2/sitl/target/exe/cf/apps/LD.so
+      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/LD.so
     short_name: ld
     long_name: Landing Determination
     events:
@@ -5939,7 +5939,7 @@ modules:
 
   lgc:
     elf_files:
-      - ../airliner/build/bebop2/sitl/target/exe/cf/apps/LGC.so
+      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/LGC.so
     short_name: lgc
     long_name: Landing Gear Control
     events:
@@ -6067,7 +6067,7 @@ modules:
 
   mac:
     elf_files:
-      - ../airliner/build/bebop2/sitl/target/exe/cf/apps/MAC.so
+      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/MAC.so
     short_name: mac
     long_name: Multicopter Attitude Controller
     events:
@@ -6171,7 +6171,7 @@ modules:
 
   mavlink:
     elf_files:
-      - ../airliner/build/bebop2/sitl/target/exe/cf/apps/MAVLINK.so
+      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/MAVLINK.so
     short_name: mavlink
     long_name: Mavlink Interface
     events:
@@ -6317,7 +6317,7 @@ modules:
 
   md:
     elf_files:
-      - ../airliner/build/bebop2/sitl/target/exe/cf/apps/MD.so
+      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/MD.so
     short_name: md
     long_name: Memory Dwell
     events:
@@ -6517,7 +6517,7 @@ modules:
 
   mm:
     elf_files:
-      - ../airliner/build/bebop2/sitl/target/exe/cf/apps/MM.so
+      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/MM.so
     short_name: mm
     long_name: Memory Manager
     events:
@@ -6857,7 +6857,7 @@ modules:
 
   mpc:
     elf_files:
-      - ../airliner/build/bebop2/sitl/target/exe/cf/apps/MPC.so
+      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/MPC.so
     short_name: mpc
     long_name: Multicopter Position Controller
     events:
@@ -7015,7 +7015,7 @@ modules:
 
   mpu6050:
     elf_files:
-      - ../airliner/build/bebop2/sitl/target/exe/cf/apps/MPU6050.so
+      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/MPU6050.so
     short_name: mpu6050
     long_name:
     events:
@@ -7210,7 +7210,7 @@ modules:
 
   mpu9250:
     elf_files:
-      - ../airliner/build/bebop2/sitl/target/exe/cf/apps/MPU9250.so
+      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/MPU9250.so
     short_name: mpu9250
     long_name:
     events:
@@ -7407,7 +7407,7 @@ modules:
 
   ms5607:
     elf_files:
-      - ../airliner/build/bebop2/sitl/target/exe/cf/apps/MS5607.so
+      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/MS5607.so
     short_name: ms5607
     long_name:
     events:
@@ -7548,7 +7548,7 @@ modules:
 
   ms5611:
     elf_files:
-      - ../airliner/build/bebop2/sitl/target/exe/cf/apps/MS5611.so
+      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/MS5611.so
     short_name: ms5611
     long_name:
     events:
@@ -7679,7 +7679,7 @@ modules:
 
   nav:
     elf_files:
-      - ../airliner/build/bebop2/sitl/target/exe/cf/apps/NAV.so
+      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/NAV.so
     short_name: nav
     long_name: Navigation
     events:
@@ -7828,7 +7828,7 @@ modules:
 
   prmlib:
     elf_files:
-      - ../airliner/build/bebop2/sitl/target/exe/cf/apps/PRMLIB.so
+      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/PRMLIB.so
     short_name: prmlib
     long_name: Parameters
     events: {}
@@ -7905,7 +7905,7 @@ modules:
 
   pe:
     elf_files:
-      - ../airliner/build/bebop2/sitl/target/exe/cf/apps/PE.so
+      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/PE.so
     short_name: pe
     long_name: Position Estimator
     events:
@@ -8227,7 +8227,7 @@ modules:
 
   qae:
     elf_files:
-      - ../airliner/build/bebop2/sitl/target/exe/cf/apps/QAE.so
+      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/QAE.so
     short_name: qae
     long_name: Attitude Estimator
     events:
@@ -8360,7 +8360,7 @@ modules:
 
   rcin:
     elf_files:
-      - ../airliner/build/bebop2/sitl/target/exe/cf/apps/RCIN.so
+      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/RCIN.so
     short_name: rcin
     long_name: Radio Control Input
     events:
@@ -8484,7 +8484,7 @@ modules:
 
   rgbled:
     elf_files:
-      - ../airliner/build/bebop2/sitl/target/exe/cf/apps/RGBLED.so
+      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/RGBLED.so
     short_name: rgbled
     long_name: RGB LED Control
     events:
@@ -8598,7 +8598,7 @@ modules:
 
   sbn:
     elf_files:
-      - ../airliner/build/bebop2/sitl/target/exe/cf/apps/SBN.so
+      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/SBN.so
     short_name: sbn
     long_name: Software Bus Network
     events: {}
@@ -8616,7 +8616,7 @@ modules:
 
   sc:
     elf_files:
-      - ../airliner/build/bebop2/sitl/target/exe/cf/apps/SC.so
+      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/SC.so
     short_name: sc
     long_name: Stored Command
     events:
@@ -9089,7 +9089,7 @@ modules:
 
   sch:
     elf_files:
-      - ../airliner/build/bebop2/sitl/target/exe/cf/apps/SCH.so
+      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/SCH.so
     short_name: sch
     long_name: Scheduler
     events:
@@ -9364,7 +9364,7 @@ modules:
 
   sens:
     elf_files:
-      - ../airliner/build/bebop2/sitl/target/exe/cf/apps/SENS.so
+      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/SENS.so
     short_name: sens
     long_name: Sensor Application
     events:
@@ -9489,7 +9489,7 @@ modules:
 
   sim:
     elf_files:
-      - ../airliner/build/bebop2/sitl/target/exe/cf/apps/SIM.so
+      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/SIM.so
     short_name: sim
     long_name: Simulation Application
     events:
@@ -9626,7 +9626,7 @@ modules:
 
   sonar:
     elf_files:
-      - ../airliner/build/bebop2/sitl/target/exe/cf/apps/SONAR.so
+      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/SONAR.so
     short_name: sonar
     long_name: Sonar Driver
     events:
@@ -9763,7 +9763,7 @@ modules:
 
   to:
     elf_files:
-      - ../airliner/build/bebop2/sitl/target/exe/cf/apps/TO.so
+      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/TO.so
     short_name: to
     long_name: Telemetry Output
     events:
@@ -10013,7 +10013,7 @@ modules:
 
   ulr:
     elf_files:
-      - ../airliner/build/bebop2/sitl/target/exe/cf/apps/ULR.so
+      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/ULR.so
     short_name: ulr
     long_name: uLanding Radar Driver
     events:
@@ -10153,7 +10153,7 @@ modules:
 
   vc:
     elf_files:
-      - ../airliner/build/bebop2/sitl/target/exe/cf/apps/VC.so
+      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/VC.so
     short_name: vc
     long_name: Video Control
     events:
@@ -10360,7 +10360,7 @@ modules:
 
   vm:
     elf_files:
-      - ../airliner/build/bebop2/sitl/target/exe/cf/apps/VM.so
+      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/VM.so
     short_name: vm
     long_name: Vehicle Manager
     events:
@@ -10674,7 +10674,7 @@ modules:
 
   px4lib:
     elf_files:
-      - ../airliner/build/bebop2/sitl/target/exe/cf/apps/PX4LIB.so
+      - ../airliner/build/build/tutorial/cfs/target/exe/cf/apps/PX4LIB.so
     short_name: px4lib
     long_name: PX4 Library
     events: {}


### PR DESCRIPTION
The `combined.yml` config file uses the `tutorial/cfs` airliner build by default now. This will make the config file consistent with the instructions in `auto-yamcs`, which in turn will make the documentation more user-friendly.

This has config file been tested in `auto-yamcs`.